### PR TITLE
Seperate Stock Page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -162,29 +162,6 @@ async function DashboardData() {
       (outwardByInumber[item.inumber] || 0) + qty;
   });
 
-  // === Customer Stock (remaining qty per customer, per inward) ===
-  const customerStockMap: Record<string, { totalRemaining: number; inwards: Array<{ id: string; inumber: string; item: string; addDate: string; inwardQty: number; remaining: number }> }> = {};
-  inwardData.forEach((item) => {
-    const inwardQty = parseInt(item.quantity) || 0;
-    const outwardQty = outwardByInumber[item.inumber] || 0;
-    const remaining = inwardQty - outwardQty;
-    if (!customerStockMap[item.customer]) {
-      customerStockMap[item.customer] = { totalRemaining: 0, inwards: [] };
-    }
-    customerStockMap[item.customer].totalRemaining += remaining;
-    customerStockMap[item.customer].inwards.push({
-      id: item.id,
-      inumber: item.inumber,
-      item: item.item,
-      addDate: item.addDate.toISOString(),
-      inwardQty,
-      remaining,
-    });
-  });
-  const customerStock = Object.entries(customerStockMap)
-    .map(([customer, data]) => ({ customer, ...data }))
-    .sort((a, b) => b.totalRemaining - a.totalRemaining);
-
   // === Missing Rate Alerts (inward records with missing store_rate or labour_rate) ===
   const missingRateAlerts = inwardData
     .filter((item) => {
@@ -634,7 +611,6 @@ async function DashboardData() {
       recentlyDeleted={recentlyDeleted}
       missingRateAlerts={missingRateAlerts}
       rateChangeLogs={rateChangeLogs}
-      customerStock={customerStock}
     />
   );
 }

--- a/src/app/dashboard/stock/page.tsx
+++ b/src/app/dashboard/stock/page.tsx
@@ -1,0 +1,102 @@
+import React, { Suspense } from "react";
+import { db } from "@/lib/db";
+import StockTab from "@/components/dashboard/StockTab";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Package } from "lucide-react";
+
+async function StockData() {
+  const [inwardData, outwardData] = await Promise.all([
+    db.inward.findMany({
+      select: {
+        id: true,
+        inumber: true,
+        customer: true,
+        item: true,
+        quantity: true,
+        addDate: true,
+      },
+      orderBy: { addDate: "desc" },
+    }),
+    db.outward.findMany({
+      select: {
+        inumber: true,
+        quantity: true,
+      },
+    }),
+  ]);
+
+  const outwardByInumber: Record<string, number> = {};
+  outwardData.forEach((item) => {
+    const qty = parseInt(item.quantity) || 0;
+    outwardByInumber[item.inumber] = (outwardByInumber[item.inumber] || 0) + qty;
+  });
+
+  const customerStockMap: Record<
+    string,
+    {
+      totalRemaining: number;
+      inwards: Array<{
+        id: string;
+        inumber: string;
+        item: string;
+        addDate: string;
+        inwardQty: number;
+        remaining: number;
+      }>;
+    }
+  > = {};
+
+  inwardData.forEach((item) => {
+    const inwardQty = parseInt(item.quantity) || 0;
+    const outwardQty = outwardByInumber[item.inumber] || 0;
+    const remaining = inwardQty - outwardQty;
+    if (!customerStockMap[item.customer]) {
+      customerStockMap[item.customer] = { totalRemaining: 0, inwards: [] };
+    }
+    customerStockMap[item.customer].totalRemaining += remaining;
+    customerStockMap[item.customer].inwards.push({
+      id: item.id,
+      inumber: item.inumber,
+      item: item.item,
+      addDate: item.addDate.toISOString(),
+      inwardQty,
+      remaining,
+    });
+  });
+
+  const customerStock = Object.entries(customerStockMap)
+    .map(([customer, data]) => ({ customer, ...data }))
+    .sort((a, b) => b.totalRemaining - a.totalRemaining);
+
+  return <StockTab customerStock={customerStock} />;
+}
+
+const StockPage = () => {
+  return (
+    <div>
+      <div className="flex h-14 lg:h-16 items-center gap-4 border-b bg-muted/40 px-6">
+        <Package className="h-5 w-5 text-muted-foreground" />
+        <span className="font-medium text-foreground">Stock</span>
+      </div>
+      <div className="p-4 space-y-5">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">Stock</h1>
+        <Suspense
+          fallback={
+            <div className="space-y-4">
+              <div className="flex gap-2">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-10 w-48 rounded-md" />
+                ))}
+              </div>
+              <Skeleton className="h-[500px] w-full rounded-xl" />
+            </div>
+          }
+        >
+          <StockData />
+        </Suspense>
+      </div>
+    </div>
+  );
+};
+
+export default StockPage;

--- a/src/components/dashboard/DashboardSummary.tsx
+++ b/src/components/dashboard/DashboardSummary.tsx
@@ -6,7 +6,6 @@ import {
   BarChart3,
   TrendingUp,
   AlertTriangle,
-  Package,
   Shield,
 } from "lucide-react";
 import { signOut } from "next-auth/react";
@@ -15,7 +14,6 @@ import OverviewTab from "./OverviewTab";
 import AnalyticsTab from "./AnalyticsTab";
 import AlertsTab from "./AlertsTab";
 import MonitoringTab from "./MonitoringTab";
-import StockTab from "./StockTab";
 import type { Props } from "./types";
 
 const DashboardSummary: React.FC<Props> = ({
@@ -38,9 +36,8 @@ const DashboardSummary: React.FC<Props> = ({
   recentlyDeleted,
   missingRateAlerts,
   rateChangeLogs,
-  customerStock,
 }) => {
-  const [activeTab, setActiveTab] = useState<"overview" | "analytics" | "alerts" | "monitoring" | "stock">("overview");
+  const [activeTab, setActiveTab] = useState<"overview" | "analytics" | "alerts" | "monitoring">("overview");
 
   const totalAlerts = useMemo(() => {
     return (
@@ -58,7 +55,6 @@ const DashboardSummary: React.FC<Props> = ({
     { key: "analytics" as const, label: "Analytics", icon: <TrendingUp className="h-3.5 w-3.5" /> },
     { key: "alerts" as const, label: "Alerts", icon: <AlertTriangle className="h-3.5 w-3.5" />, badge: totalAlerts },
     { key: "monitoring" as const, label: "Monitoring", icon: <Shield className="h-3.5 w-3.5" /> },
-    { key: "stock" as const, label: "Stock", icon: <Package className="h-3.5 w-3.5" /> },
   ];
 
   return (
@@ -143,9 +139,6 @@ const DashboardSummary: React.FC<Props> = ({
           />
         )}
 
-        {activeTab === "stock" && (
-          <StockTab customerStock={customerStock} />
-        )}
       </div>
     </div>
   );

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -210,5 +210,4 @@ export type Props = {
   recentlyDeleted: RecentlyDeletedRecord[];
   missingRateAlerts: MissingRateAlert[];
   rateChangeLogs: RateChangeLog[];
-  customerStock: CustomerStock[];
 };

--- a/src/lib/data.tsx
+++ b/src/lib/data.tsx
@@ -1,9 +1,10 @@
-import { LayoutDashboard, User, MonitorDown, MonitorUp, SquareLibrary, ReceiptText, Users, Hammer, DatabaseBackup, Eye, StickyNote, ClipboardList, Languages, ReceiptIcon, FileText } from "lucide-react";
+import { LayoutDashboard, User, MonitorDown, MonitorUp, SquareLibrary, ReceiptText, Users, Hammer, DatabaseBackup, Eye, StickyNote, ClipboardList, Languages, ReceiptIcon, FileText, Package } from "lucide-react";
 
 export const sidebar = [
   { title: "Dashboard", link: "/dashboard", icon: <LayoutDashboard /> },
   { title: "Inward Gate Pass", link: "/dashboard/inward", icon: <MonitorDown /> },
   { title: "Outward Gate Pass", link: "/dashboard/outward", icon: <MonitorUp /> },
+  { title: "Stock", link: "/dashboard/stock", icon: <Package /> },
   { title: "Ledger", link: "/dashboard/ledger", icon: <SquareLibrary /> },
   { title: "Customers", link: "/dashboard/customer", icon: <Users /> },
   { title: "Bill", link: "/dashboard/bill", icon: <ReceiptText /> },


### PR DESCRIPTION
## Summary

- Moved the Stock tab out of the Dashboard and into its own dedicated page at `/dashboard/stock`
- Added **Stock** to the sidebar navigation (between Outward Gate Pass and Ledger) using the `Package` icon
- Stock page is visible to both **admin** and **super admin** roles
- Cleaned up `DashboardSummary` by removing the Stock tab, its import, and the `customerStock` prop
- Removed `customerStock` from the dashboard's data fetching logic and `Props` type — stock data is now fetched independently on the Stock page

## Changes

- `src/app/dashboard/stock/page.tsx` — new server component that fetches and computes customer stock data, renders `StockTab`
- `src/lib/data.tsx` — added Stock entry to sidebar
- `src/components/dashboard/DashboardSummary.tsx` — removed Stock tab and related code
- `src/components/dashboard/types.ts` — removed `customerStock` from `Props`
- `src/app/dashboard/page.tsx` — removed `customerStock` data computation and prop
