### PR TITLE
Add expandable contact details to Customer List

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,3 +130,16 @@ model InvoiceCounter {
   year    Int    @unique
   counter Int    @default(0)
 }
+
+type CustomerContact {
+  name  String
+  phone String
+}
+
+model CustomerDetail {
+  id        String            @id @default(auto()) @map("_id") @db.ObjectId
+  customer  String            @unique
+  contacts  CustomerContact[]
+  createdAt DateTime          @default(now())
+  updatedAt DateTime          @updatedAt
+}

--- a/src/app/api/customer-details/route.ts
+++ b/src/app/api/customer-details/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const customer = request.nextUrl.searchParams.get('customer');
+  if (!customer) {
+    return NextResponse.json({ error: 'customer param required' }, { status: 400 });
+  }
+  try {
+    const detail = await db.customerDetail.findUnique({ where: { customer } });
+    return NextResponse.json(detail ?? { customer, contacts: [] });
+  } catch (error) {
+    console.error('Failed to fetch customer detail:', error);
+    return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { customer, contacts } = body as {
+      customer: string;
+      contacts: { name: string; phone: string }[];
+    };
+
+    if (!customer) {
+      return NextResponse.json({ error: 'customer required' }, { status: 400 });
+    }
+
+    const detail = await db.customerDetail.upsert({
+      where: { customer },
+      update: { contacts },
+      create: { customer, contacts },
+    });
+
+    return NextResponse.json(detail);
+  } catch (error) {
+    console.error('Failed to save customer detail:', error);
+    return NextResponse.json({ error: 'Failed to save' }, { status: 500 });
+  }
+}

--- a/src/components/customer/CustomerPage.tsx
+++ b/src/components/customer/CustomerPage.tsx
@@ -13,7 +13,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { ArrowUpDown, ChevronDown, Search } from "lucide-react";
+import { ArrowUpDown, ChevronDown, ChevronUp, Plus, Search, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -32,18 +32,121 @@ import {
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
 import { signOut } from "next-auth/react";
-import DarkModeToggle from '../DarkModeToggle'
+import DarkModeToggle from '../DarkModeToggle';
 
 interface CustomerData {
   customer: string;
   totalInwards: number;
 }
 
-const columns: ColumnDef<CustomerData>[] = [
-  {
-    accessorKey: "customer",
-    header: ({ column }) => {
-      return (
+interface Contact {
+  name: string;
+  phone: string;
+}
+
+interface ExpandedState {
+  contacts: Contact[];
+  loading: boolean;
+  saving: boolean;
+  saved: boolean;
+}
+
+const CustomerPage = ({ data }: { data: CustomerData[] }) => {
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
+  const [rowSelection, setRowSelection] = React.useState({});
+  const [expandedCustomer, setExpandedCustomer] = React.useState<string | null>(null);
+  const [expandedState, setExpandedState] = React.useState<ExpandedState>({
+    contacts: [],
+    loading: false,
+    saving: false,
+    saved: false,
+  });
+
+  const handleRowClick = async (customerName: string) => {
+    if (expandedCustomer === customerName) {
+      setExpandedCustomer(null);
+      return;
+    }
+
+    setExpandedCustomer(customerName);
+    setExpandedState({ contacts: [], loading: true, saving: false, saved: false });
+
+    try {
+      const res = await fetch(`/api/customer-details?customer=${encodeURIComponent(customerName)}`);
+      const data = await res.json();
+      const contacts: Contact[] = (data.contacts ?? []).length > 0
+        ? data.contacts
+        : [{ name: "", phone: "" }];
+      setExpandedState({ contacts, loading: false, saving: false, saved: false });
+    } catch {
+      setExpandedState({ contacts: [{ name: "", phone: "" }], loading: false, saving: false, saved: false });
+    }
+  };
+
+  const updateContact = (index: number, field: keyof Contact, value: string) => {
+    if (field === "phone") {
+      // Only allow digits, max 11
+      const digits = value.replace(/\D/g, "").slice(0, 11);
+      setExpandedState((prev) => {
+        const contacts = [...prev.contacts];
+        contacts[index] = { ...contacts[index], [field]: digits };
+        return { ...prev, contacts, saved: false };
+      });
+    } else {
+      setExpandedState((prev) => {
+        const contacts = [...prev.contacts];
+        contacts[index] = { ...contacts[index], [field]: value };
+        return { ...prev, contacts, saved: false };
+      });
+    }
+  };
+
+  const addContact = () => {
+    setExpandedState((prev) => ({
+      ...prev,
+      contacts: [...prev.contacts, { name: "", phone: "" }],
+      saved: false,
+    }));
+  };
+
+  const removeContact = (index: number) => {
+    setExpandedState((prev) => {
+      const contacts = prev.contacts.filter((_, i) => i !== index);
+      return { ...prev, contacts: contacts.length > 0 ? contacts : [{ name: "", phone: "" }], saved: false };
+    });
+  };
+
+  const saveContacts = async () => {
+    if (!expandedCustomer) return;
+
+    // Validate: all filled entries must have 11-digit phone
+    const filled = expandedState.contacts.filter((c) => c.name.trim() || c.phone.trim());
+    for (const c of filled) {
+      if (c.phone.length !== 11) {
+        alert("Phone number must be exactly 11 digits.");
+        return;
+      }
+    }
+
+    setExpandedState((prev) => ({ ...prev, saving: true }));
+    try {
+      await fetch("/api/customer-details", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ customer: expandedCustomer, contacts: filled }),
+      });
+      setExpandedState((prev) => ({ ...prev, saving: false, saved: true }));
+    } catch {
+      setExpandedState((prev) => ({ ...prev, saving: false }));
+    }
+  };
+
+  const columns: ColumnDef<CustomerData>[] = React.useMemo(() => [
+    {
+      accessorKey: "customer",
+      header: ({ column }) => (
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
@@ -51,14 +154,27 @@ const columns: ColumnDef<CustomerData>[] = [
           Customer Name
           <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
-      );
+      ),
+      cell: ({ row }) => {
+        const name = row.getValue("customer") as string;
+        const isOpen = expandedCustomer === name;
+        return (
+          <button
+            className="flex items-center gap-1 capitalize font-medium hover:text-blue-600 transition-colors cursor-pointer"
+            onClick={() => handleRowClick(name)}
+          >
+            {name}
+            {isOpen
+              ? <ChevronUp className="h-4 w-4 text-muted-foreground" />
+              : <ChevronDown className="h-4 w-4 text-muted-foreground" />
+            }
+          </button>
+        );
+      },
     },
-    cell: ({ row }) => <div className="capitalize">{row.getValue("customer")}</div>,
-  },
-  {
-    accessorKey: "totalInwards",
-    header: ({ column }) => {
-      return (
+    {
+      accessorKey: "totalInwards",
+      header: ({ column }) => (
         <Button
           variant="ghost"
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
@@ -66,17 +182,11 @@ const columns: ColumnDef<CustomerData>[] = [
           Total Inwards
           <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
-      );
+      ),
+      cell: ({ row }) => <div className="pl-8">{row.getValue("totalInwards")}</div>,
     },
-    cell: ({ row }) => <div className="pl-8">{row.getValue("totalInwards")}</div>,
-  },
-];
-
-const CustomerPage = ({ data }: { data: CustomerData[] }) => {
-  const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
-  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({});
-  const [rowSelection, setRowSelection] = React.useState({});
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ], [expandedCustomer]);
 
   const table = useReactTable({
     data,
@@ -121,18 +231,16 @@ const CustomerPage = ({ data }: { data: CustomerData[] }) => {
                 {table
                   .getAllColumns()
                   .filter((column) => column.getCanHide())
-                  .map((column) => {
-                    return (
-                      <DropdownMenuCheckboxItem
-                        key={column.id}
-                        className="capitalize"
-                        checked={column.getIsVisible()}
-                        onCheckedChange={(value) => column.toggleVisibility(!!value)}
-                      >
-                        {column.id}
-                      </DropdownMenuCheckboxItem>
-                    );
-                  })}
+                  .map((column) => (
+                    <DropdownMenuCheckboxItem
+                      key={column.id}
+                      className="capitalize"
+                      checked={column.getIsVisible()}
+                      onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                    >
+                      {column.id}
+                    </DropdownMenuCheckboxItem>
+                  ))}
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
@@ -144,13 +252,11 @@ const CustomerPage = ({ data }: { data: CustomerData[] }) => {
       </div>
       <div className="p-6">
         <div className="flex items-center justify-between pt-3 pb-6">
-          <h1 className="text-3xl font-bold tracking-tight">
-            Customer List
-          </h1>
+          <h1 className="text-3xl font-bold tracking-tight">Customer List</h1>
           <div className="flex items-center space-x-2 text-sm font-medium bg-muted rounded-full px-4 py-2 shadow-sm">
-  <span className="text-muted-foreground">Total Customers:</span>
-  <span className="text-green-600 font-bold">{data.length}</span>
-</div>
+            <span className="text-muted-foreground">Total Customers:</span>
+            <span className="text-green-600 font-bold">{data.length}</span>
+          </div>
         </div>
         <div>
           <div className="rounded-md border">
@@ -158,44 +264,101 @@ const CustomerPage = ({ data }: { data: CustomerData[] }) => {
               <TableHeader>
                 {table.getHeaderGroups().map((headerGroup) => (
                   <TableRow key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => {
-                      return (
-                        <TableHead key={header.id}>
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext()
-                              )}
-                        </TableHead>
-                      );
-                    })}
+                    {headerGroup.headers.map((header) => (
+                      <TableHead key={header.id}>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(header.column.columnDef.header, header.getContext())}
+                      </TableHead>
+                    ))}
                   </TableRow>
                 ))}
               </TableHeader>
               <TableBody>
                 {table.getRowModel().rows?.length ? (
-                  table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      data-state={row.getIsSelected() && "selected"}
-                    >
-                      {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
-                          {flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext()
-                          )}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))
+                  table.getRowModel().rows.map((row) => {
+                    const customerName = row.getValue("customer") as string;
+                    const isExpanded = expandedCustomer === customerName;
+                    return (
+                      <React.Fragment key={row.id}>
+                        <TableRow data-state={row.getIsSelected() && "selected"}>
+                          {row.getVisibleCells().map((cell) => (
+                            <TableCell key={cell.id}>
+                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </TableCell>
+                          ))}
+                        </TableRow>
+
+                        {isExpanded && (
+                          <TableRow className="bg-muted/30 hover:bg-muted/30">
+                            <TableCell colSpan={columns.length} className="py-4 px-6">
+                              {expandedState.loading ? (
+                                <p className="text-sm text-muted-foreground">Loading...</p>
+                              ) : (
+                                <div className="space-y-3">
+                                  <p className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+                                    Contact Numbers
+                                  </p>
+
+                                  {expandedState.contacts.map((contact, i) => (
+                                    <div key={i} className="flex items-center gap-3">
+                                      <Input
+                                        placeholder="Contact name"
+                                        value={contact.name}
+                                        onChange={(e) => updateContact(i, "name", e.target.value)}
+                                        className="max-w-[180px]"
+                                      />
+                                      <Input
+                                        placeholder="11-digit phone"
+                                        value={contact.phone}
+                                        onChange={(e) => updateContact(i, "phone", e.target.value)}
+                                        className="max-w-[160px]"
+                                        maxLength={11}
+                                        inputMode="numeric"
+                                      />
+                                      <span className={`text-xs tabular-nums ${contact.phone.length === 11 ? "text-green-600" : "text-muted-foreground"}`}>
+                                        {contact.phone.length}/11
+                                      </span>
+                                      <button
+                                        onClick={() => removeContact(i)}
+                                        className="text-muted-foreground hover:text-red-500 transition-colors"
+                                        title="Remove"
+                                      >
+                                        <Trash2 className="h-4 w-4" />
+                                      </button>
+                                    </div>
+                                  ))}
+
+                                  <div className="flex items-center gap-3 pt-1">
+                                    <button
+                                      onClick={addContact}
+                                      className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 transition-colors"
+                                    >
+                                      <Plus className="h-4 w-4" />
+                                      Add another
+                                    </button>
+                                    <Button
+                                      size="sm"
+                                      onClick={saveContacts}
+                                      disabled={expandedState.saving}
+                                    >
+                                      {expandedState.saving ? "Saving..." : "Save"}
+                                    </Button>
+                                    {expandedState.saved && (
+                                      <span className="text-sm text-green-600">Saved</span>
+                                    )}
+                                  </div>
+                                </div>
+                              )}
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </React.Fragment>
+                    );
+                  })
                 ) : (
                   <TableRow>
-                    <TableCell
-                      colSpan={columns.length}
-                      className="h-24 text-center"
-                    >
+                    <TableCell colSpan={columns.length} className="h-24 text-center">
                       No results.
                     </TableCell>
                   </TableRow>


### PR DESCRIPTION
### Summary
- Added `CustomerDetail` model to Prisma schema with support for multiple name + phone number pairs per customer (stored as an embedded array in MongoDB)
- Created `/api/customer-details` API route with GET (fetch by customer name) and POST (upsert contacts)
- Updated `CustomerPage` with expandable rows, clicking a customer name toggles an inline form below the row

### Changes
- `prisma/schema.prisma` — new `CustomerContact` composite type and `CustomerDetail` model
- `src/app/api/customer-details/route.ts` — new API route for fetching and saving customer contacts
- `src/components/customer/CustomerPage.tsx` — expandable row UI with add/remove contact pairs, 11-digit phone validation, and save confirmation

### How it works
1. Click any customer name in the list, a dropdown expands below the row
2. Add as many name + phone number pairs as needed
3. Phone numbers are restricted to 11 digits with a live counter
4. Click **Save** to persist, data reloads from the database next time the row is opened
5. Click the name again to collapse