### PR TITLE
Add quantity totals to Labour Bill summary cards

### DIFF
--- a/src/components/labour/LabourBillPage.tsx
+++ b/src/components/labour/LabourBillPage.tsx
@@ -510,6 +510,9 @@ const LabourBillPage = () => {
                     <p className="text-2xl font-bold text-blue-900 dark:text-blue-100">
                       Rs. {labourData.inwardTotal.toLocaleString('en-IN', { minimumFractionDigits: 2 })}
                     </p>
+                    <p className="text-sm text-blue-700 dark:text-blue-300 font-medium">
+                      Qty: {labourData.inwardData.reduce((sum, item) => sum + item.quantity, 0).toLocaleString('en-IN')}
+                    </p>
                     <p className="text-sm text-blue-600 dark:text-blue-400">{labourData.inwardData.length} record(s)</p>
                   </div>
 
@@ -520,6 +523,9 @@ const LabourBillPage = () => {
                     </div>
                     <p className="text-2xl font-bold text-orange-900 dark:text-orange-100">
                       Rs. {labourData.outwardTotal.toLocaleString('en-IN', { minimumFractionDigits: 2 })}
+                    </p>
+                    <p className="text-sm text-orange-700 dark:text-orange-300 font-medium">
+                      Qty: {labourData.outwardData.reduce((sum, item) => sum + item.quantity, 0).toLocaleString('en-IN')}
                     </p>
                     <p className="text-sm text-orange-600 dark:text-orange-400">{labourData.outwardData.length} record(s)</p>
                   </div>


### PR DESCRIPTION
## Summary

- Added total inward quantity display to the Inward Labour summary card
- Added total outward quantity display to the Outward Labour summary card
- Quantities are computed client-side by summing the `quantity` field across all records in the existing API response 

## Changes

- `LabourBillPage.tsx`: Added a `Qty: X` line to the Inward and Outward summary cards, displayed between the labour cost and the record count